### PR TITLE
Use github public ubuntu runner instead of self-hosted on public repos

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -93,7 +93,7 @@ on:
 jobs:
 
   build-prep:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     outputs:
       semVer: ${{ steps.buildprepversion.outputs.version }}
       chart-version: ${{ steps.buildversion.outputs.chart-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [3.0.2] - 2022-03-04
+
+### Changed
+
+- Switch build prep workflow to use GH ubuntu runner instead of self-hosted for security reasons
+
 ## [3.0.1] - 2022-02-11
 
 ### Added


### PR DESCRIPTION
## Summary and Scope

Use github public ubuntu runner instead of self-hosted on public repos.

## Issues and Related PRs

* Resolves CASMCMS-7878

## Testing

Chart built successfully with proper version.

## Risks and Mitigations

No

## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
