### PR TITLE
CASMCMS-7890: CF_IMPORT_FORCE_EXISTING_BRANCH parameter added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added support for `CF_IMPORT_FORCE_EXISTING_BRANCH` from cf-gitea-import v1.6.0.
+
 ## [3.0.2] - 2022-03-04
 
 ### Changed

--- a/charts/cray-import-config/templates/job.yaml
+++ b/charts/cray-import-config/templates/job.yaml
@@ -84,6 +84,8 @@ spec:
           value: "{{ .Values.import_job.CF_IMPORT_PROTECT_BRANCH }}"
         - name: CF_IMPORT_PRIVATE_REPO
           value: "{{ .Values.import_job.CF_IMPORT_PRIVATE_REPO }}"
+        - name: CF_IMPORT_FORCE_EXISTING_BRANCH
+          value: "{{ .Values.import_job.CF_IMPORT_FORCE_EXISTING_BRANCH }}"
         - name: CF_IMPORT_GITEA_USER
           valueFrom:
             secretKeyRef:

--- a/charts/cray-import-config/values.yaml
+++ b/charts/cray-import-config/values.yaml
@@ -21,10 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-# Full image including repo, e.g. dtr.dev.cray.com/cray/config-image:1.2.3
-#                                                   ^                 ^
-#                                                   |                 |
-#                                             ['repository]         [tag]
+# The image that contains the config content (based on cf-gitea-import)
 config_image:
   image:
     repository: ""
@@ -55,6 +52,7 @@ import_job:
   CF_IMPORT_CONTENT: "/content"
   CF_IMPORT_PROTECT_BRANCH: "true"
   CF_IMPORT_PRIVATE_REPO: "true"
+  CF_IMPORT_FORCE_EXISTING_BRANCH: "false"
 
   # Specify the user/password of the gitea user from a k8s secret
   CF_IMPORT_GITEA_USER_SECRET: "vcs-user-credentials"


### PR DESCRIPTION
## Summary and Scope

Expose the new CF_IMPORT_FORCE_EXISTING_BRANCH parameter added to cf-gitea-import in v1.6.0

## Issues and Related PRs

* Resolves CASMCMS-7890

## Testing

### Tested on:

  * Mug

### Test description:

Added to csm-config chart manually and rebuilt. Multiple chart updates with parameter toggled worked as intended.

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable

